### PR TITLE
Add documentation in key (such as statemachine key) intellisense

### DIFF
--- a/extension/src/completion/KeyCompletionProvider.ts
+++ b/extension/src/completion/KeyCompletionProvider.ts
@@ -26,6 +26,8 @@ export class KeyCompletionProvider implements CompletionProvider {
                 const item = new vscode.CompletionItem(details.name);
                 item.insertText = `${this.keyPrefix}${details.id}`;
                 item.filterText = item.insertText;
+                item.detail = "Key value:";
+                item.documentation = item.insertText;
                 return item;
             });
     }

--- a/extension/test/extension.stateDataCompletion.test.ts
+++ b/extension/test/extension.stateDataCompletion.test.ts
@@ -77,9 +77,11 @@ describe("StateCompletionItemProvider Tests", () => {
                 completionItems.length.should.eql(2);
                 completionItems[0].insertText.should.eql("StateMachine2");
                 completionItems[0].filterText.should.eql("StateMachine2");
+                completionItems[0].documentation.should.eql("StateMachine2");
                 completionItems[0].label.should.eql("TestSpec");
                 completionItems[1].insertText.should.eql("StateMachine1");
                 completionItems[1].filterText.should.eql("StateMachine1");
+                completionItems[1].documentation.should.eql("StateMachine1");
                 completionItems[1].label.should.eql("TechTestManger");
             }, reason => {
                 console.error(reason);


### PR DESCRIPTION
For example:
SubGraphKey intellisense should provide autocomplete containing state machine names as label and state machine keys as inserted value